### PR TITLE
Refactor: typed Identification + PythonRPCTransport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@ env/
 ENV/
 
 # ML model weights (large, fetched/downloaded locally)
-models/
+/models/
 *.safetensors
 *.gguf
 *.bin

--- a/Naturista/Naturista.xcodeproj/project.pbxproj
+++ b/Naturista/Naturista.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		308875B2A873464E6C37D236 /* EntryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3DDF8BBC226266CE81F052 /* EntryDetailView.swift */; };
 		41094921254A75610859A08B /* DesignSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8923C286130387CA6D6A0535 /* DesignSystem.swift */; };
 		4A0B752B447E2F3B3EAD87DC /* PipelineService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094559EF8E72A8C8F42F2CDB /* PipelineService.swift */; };
+		5E1D91126316E1D1C7F0F92B /* ModelLease.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76EC9D72211FBCA508849D25 /* ModelLease.swift */; };
 		6C61578CB133CF9A594F6B2C /* PlateCompositor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C80FEE2509F98204617501E /* PlateCompositor.swift */; };
 		7176A18571C50BA96CFA2C9C /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AFF4097CF8FA255A915845 /* Entry.swift */; };
 		7C64DEEF0FAD89393A62A278 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B967B310FF31D71376E434A8 /* ContentView.swift */; };
@@ -21,6 +22,7 @@
 		A1C8E6C0C433315C53466E11 /* ImportFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 325628BEE263E4D9F645EC4E /* ImportFlowView.swift */; };
 		A42055F4F7F9120036CD716E /* DatabaseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B504B60487765D53F14212CA /* DatabaseService.swift */; };
 		AE87A01E1727F7C79F9D612D /* LibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1161E205FD047A0C8554A2 /* LibraryView.swift */; };
+		AFA351B4AA28BADE54A0BDAE /* PythonRPCTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B09FCD21D5C47D38C0D166 /* PythonRPCTransport.swift */; };
 		BDDF8C4AEFDF4CDACF6B8A77 /* ModelConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F91446092340D77A9CE8D8 /* ModelConfig.swift */; };
 		BE1B495B9B8A25D2C0654CEF /* PlateFrameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 067BC6A8DBB3821BAE3E87A4 /* PlateFrameView.swift */; };
 		DC98D1E2BD479B4C99533722 /* PhotoImportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE77B46A031D569A91996054 /* PhotoImportService.swift */; };
@@ -39,10 +41,12 @@
 		325628BEE263E4D9F645EC4E /* ImportFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportFlowView.swift; sourceTree = "<group>"; };
 		3F3DDF8BBC226266CE81F052 /* EntryDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryDetailView.swift; sourceTree = "<group>"; };
 		41946F89622E52C94B9BEE70 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		49B09FCD21D5C47D38C0D166 /* PythonRPCTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PythonRPCTransport.swift; sourceTree = "<group>"; };
 		57FDE4D6B25BDAE739421AAC /* FluxActor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FluxActor.swift; sourceTree = "<group>"; };
 		5F3849A5EFBD81B6DE796D26 /* Naturista.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Naturista.entitlements; sourceTree = "<group>"; };
 		6BB4C187F34ACDF049664D78 /* Naturista.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Naturista.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6C80FEE2509F98204617501E /* PlateCompositor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlateCompositor.swift; sourceTree = "<group>"; };
+		76EC9D72211FBCA508849D25 /* ModelLease.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelLease.swift; sourceTree = "<group>"; };
 		8923C286130387CA6D6A0535 /* DesignSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystem.swift; sourceTree = "<group>"; };
 		92F91446092340D77A9CE8D8 /* ModelConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelConfig.swift; sourceTree = "<group>"; };
 		9885A40592FC95CDEA5247B9 /* Identification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identification.swift; sourceTree = "<group>"; };
@@ -144,6 +148,8 @@
 			children = (
 				57FDE4D6B25BDAE739421AAC /* FluxActor.swift */,
 				C8D144E22D796AAAF1220DB4 /* GemmaActor.swift */,
+				76EC9D72211FBCA508849D25 /* ModelLease.swift */,
+				49B09FCD21D5C47D38C0D166 /* PythonRPCTransport.swift */,
 			);
 			path = AI;
 			sourceTree = "<group>";
@@ -260,10 +266,12 @@
 				A1C8E6C0C433315C53466E11 /* ImportFlowView.swift in Sources */,
 				AE87A01E1727F7C79F9D612D /* LibraryView.swift in Sources */,
 				BDDF8C4AEFDF4CDACF6B8A77 /* ModelConfig.swift in Sources */,
+				5E1D91126316E1D1C7F0F92B /* ModelLease.swift in Sources */,
 				DC98D1E2BD479B4C99533722 /* PhotoImportService.swift in Sources */,
 				4A0B752B447E2F3B3EAD87DC /* PipelineService.swift in Sources */,
 				6C61578CB133CF9A594F6B2C /* PlateCompositor.swift in Sources */,
 				BE1B495B9B8A25D2C0654CEF /* PlateFrameView.swift in Sources */,
+				AFA351B4AA28BADE54A0BDAE /* PythonRPCTransport.swift in Sources */,
 				FA7C9E798ABC95F3B4958D40 /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Naturista/Naturista.xcodeproj/project.pbxproj
+++ b/Naturista/Naturista.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0277A87C24A099DD42B21CB2 /* Identification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9885A40592FC95CDEA5247B9 /* Identification.swift */; };
 		1E6AF8ECE42F9B09EC24A9BA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0685593D984F4A6A26FCC778 /* AppDelegate.swift */; };
 		269A3B37CDD653012C0050C1 /* EntryRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9119DE66C094D14D34AFAE /* EntryRowView.swift */; };
 		308875B2A873464E6C37D236 /* EntryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3DDF8BBC226266CE81F052 /* EntryDetailView.swift */; };
@@ -44,6 +45,7 @@
 		6C80FEE2509F98204617501E /* PlateCompositor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlateCompositor.swift; sourceTree = "<group>"; };
 		8923C286130387CA6D6A0535 /* DesignSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystem.swift; sourceTree = "<group>"; };
 		92F91446092340D77A9CE8D8 /* ModelConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelConfig.swift; sourceTree = "<group>"; };
+		9885A40592FC95CDEA5247B9 /* Identification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identification.swift; sourceTree = "<group>"; };
 		99387AC62F9BCC7D67D67C7B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		B504B60487765D53F14212CA /* DatabaseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseService.swift; sourceTree = "<group>"; };
 		B967B310FF31D71376E434A8 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -132,6 +134,7 @@
 			children = (
 				B504B60487765D53F14212CA /* DatabaseService.swift */,
 				11AFF4097CF8FA255A915845 /* Entry.swift */,
+				9885A40592FC95CDEA5247B9 /* Identification.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -251,6 +254,7 @@
 				269A3B37CDD653012C0050C1 /* EntryRowView.swift in Sources */,
 				84922FADB6D9A699E156A923 /* FluxActor.swift in Sources */,
 				E98CA4ACD7928D2888A0DA11 /* GemmaActor.swift in Sources */,
+				0277A87C24A099DD42B21CB2 /* Identification.swift in Sources */,
 				8709B9D41CB55813EBC324F7 /* IdentificationPanelView.swift in Sources */,
 				FBCF5ED4091050829FFB2828 /* ImageService.swift in Sources */,
 				A1C8E6C0C433315C53466E11 /* ImportFlowView.swift in Sources */,

--- a/Sources/AI/FluxActor.swift
+++ b/Sources/AI/FluxActor.swift
@@ -1,32 +1,6 @@
 import Foundation
 
-enum FluxError: Error, LocalizedError {
-    case scriptNotFound
-    case processNotRunning
-    case malformedOutput
-    case timeout
-    case generationFailed(String)
-    case modelLoadFailed(String)
-
-    var errorDescription: String? {
-        switch self {
-        case .scriptNotFound:
-            return "FLUX Python script not found. Expected at: \( FluxActor.scriptPath)"
-        case .processNotRunning:
-            return "FLUX process is not running. Call restart() first."
-        case .malformedOutput:
-            return "FLUX returned malformed JSON. The model output could not be parsed."
-        case .timeout:
-            return "FLUX illustration generation timed out after 300 seconds."
-        case .generationFailed(let message):
-            return "Illustration generation failed: \(message)"
-        case .modelLoadFailed(let message):
-            return "Failed to load FLUX model: \(message)"
-        }
-    }
-}
-
-struct FluxGenerationResult: Codable {
+struct FluxGenerationResult: Codable, Sendable {
     var illustrationPath: String
     var seed: Int
     var timingSeconds: Double
@@ -40,185 +14,57 @@ struct FluxGenerationResult: Codable {
 
 actor FluxActor {
     static let shared = FluxActor()
-    static var scriptPath: String {
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        let naturista = appSupport.appendingPathComponent("Naturista", isDirectory: true)
-        let pythonDir = naturista.appendingPathComponent("Python", isDirectory: true)
-        return pythonDir.appendingPathComponent("flux_service.py").path
+
+    private static var scriptPath: String {
+        AppPaths.applicationSupport
+            .appendingPathComponent("Python", isDirectory: true)
+            .appendingPathComponent("flux_service.py")
+            .path
     }
 
-    private var process: Process?
-    private var inputPipe: Pipe?
-    private var outputPipe: Pipe?
-    private var isRunning = false
+    private let transport: PythonProcessTransport
 
-    private init() {}
+    private init() {
+        self.transport = PythonProcessTransport(config: .init(
+            scriptPath: FluxActor.scriptPath,
+            environment: [:],
+            timeoutSeconds: 310,
+            warmupSeconds: 2,
+            stderrLogURL: URL(fileURLWithPath: "/tmp/naturista_flux.log")
+        ))
+    }
+
+    private struct GenerateRequest: Encodable, Sendable {
+        let action: String
+        let identification_json_path: String
+        let photo_path: String
+        let output_path: String
+    }
 
     func generate(photoPath: String, identification: IdentificationResult, entryId: UUID) async throws -> String {
-        if process == nil || !isRunning {
-            try await restart()
-        }
-
-        guard let inputPipe = inputPipe, let outputPipe = outputPipe, isRunning else {
-            throw FluxError.processNotRunning
-        }
-
+        // FLUX takes the identification as a sidecar JSON file rather than
+        // inline; write it once, hand the path over, clean up on exit.
         let identificationJsonPath = AppPaths.applicationSupport
             .appendingPathComponent("temp_identification_\(entryId.uuidString).json")
-        let identificationJsonData = try JSONEncoder().encode(identification)
-        try identificationJsonData.write(to: identificationJsonPath)
-
-        defer {
-            try? FileManager.default.removeItem(at: identificationJsonPath)
-        }
+        try JSONEncoder().encode(identification).write(to: identificationJsonPath)
+        defer { try? FileManager.default.removeItem(at: identificationJsonPath) }
 
         let illustrationFilename = "\(entryId.uuidString)_illustration.png"
         let outputPath = AppPaths.illustrations.appendingPathComponent(illustrationFilename).path
-        print("[flux] requesting output_path=\(outputPath)")
-        if FileManager.default.fileExists(atPath: outputPath) {
-            let preAttrs = try? FileManager.default.attributesOfItem(atPath: outputPath)
-            let preSize = (preAttrs?[.size] as? Int) ?? -1
-            let preMtime = (preAttrs?[.modificationDate] as? Date)?.description ?? "<unknown>"
-            print("[flux] pre-existing file size=\(preSize) mtime=\(preMtime)")
-        }
 
-        let request: [String: Any] = [
-            "action": "generate",
-            "identification_json_path": identificationJsonPath.path,
-            "photo_path": photoPath,
-            "output_path": outputPath
-        ]
-
-        guard let jsonData = try? JSONSerialization.data(withJSONObject: request, options: []),
-              let jsonString = String(data: jsonData, encoding: .utf8) else {
-            throw FluxError.generationFailed("Failed to encode request JSON")
-        }
-
-        inputPipe.writePipe.write(jsonString.appending("\n").data(using: .utf8)!)
-
-        var responseData = Data()
-        let timeoutTask = Task {
-            try await Task.sleep(nanoseconds: 310_000_000_000)
-            throw FluxError.timeout
-        }
-
-        let readTask = Task {
-            while true {
-                try await Task.sleep(nanoseconds: 100_000_000)
-                let available = outputPipe.readPipe.availableData
-                if !available.isEmpty {
-                    responseData.append(available)
-                    if let responseString = String(data: responseData, encoding: .utf8),
-                       responseString.contains("\n") {
-                        let lines = responseString.components(separatedBy: "\n")
-                        if let firstLine = lines.first(where: { !$0.isEmpty }) {
-                            return firstLine
-                        }
-                    }
-                }
-            }
-        }
-
-        var resultString: String?
-        do {
-            resultString = try await readTask.value
-            timeoutTask.cancel()
-        } catch {
-            readTask.cancel()
-            timeoutTask.cancel()
-            try? await restart()
-            throw error
-        }
-
-        guard let result = resultString else {
-            throw FluxError.malformedOutput
-        }
-
-        guard let data = result.data(using: .utf8) else {
-            throw FluxError.malformedOutput
-        }
-
-        do {
-            let decoder = JSONDecoder()
-            let generationResult = try decoder.decode(FluxGenerationResult.self, from: data)
-            print("[flux] response illustration_path=\(generationResult.illustrationPath) seed=\(generationResult.seed) timing=\(generationResult.timingSeconds)s")
-            return generationResult.illustrationPath
-        } catch let error as FluxError {
-            throw error
-        } catch {
-            if result.contains("\"error\"") {
-                if let errorData = result.data(using: .utf8),
-                   let errorJson = try? JSONSerialization.jsonObject(with: errorData) as? [String: Any],
-                   let errorMessage = errorJson["error"] as? String {
-                    throw FluxError.generationFailed(errorMessage)
-                }
-            }
-            throw FluxError.malformedOutput
-        }
+        let result = try await transport.call(
+            GenerateRequest(
+                action: "generate",
+                identification_json_path: identificationJsonPath.path,
+                photo_path: photoPath,
+                output_path: outputPath
+            ),
+            responseType: FluxGenerationResult.self
+        )
+        return result.illustrationPath
     }
 
-    func restart() async throws {
-        await shutdown()
-
-        let scriptPath = FluxActor.scriptPath
-        guard FileManager.default.fileExists(atPath: scriptPath) else {
-            throw FluxError.scriptNotFound
-        }
-
-        let pythonProcess = Process()
-        pythonProcess.executableURL = URL(fileURLWithPath: NSString(string: ModelConfig.pythonPath).expandingTildeInPath)
-        pythonProcess.arguments = [scriptPath]
-
-        let input = Pipe()
-        let output = Pipe()
-        pythonProcess.standardOutput = output
-        pythonProcess.standardInput = input
-        let stderrLogPath = "/tmp/naturista_flux.log"
-        FileManager.default.createFile(atPath: stderrLogPath, contents: nil)
-        pythonProcess.standardError = FileHandle(forWritingAtPath: stderrLogPath) ?? FileHandle.nullDevice
-
-        pythonProcess.environment = [
-            "PYTHONUNBUFFERED": "1"
-        ]
-
-        var processExitedEarly = false
-        pythonProcess.terminationHandler = { proc in
-            if proc.terminationStatus != 0 {
-                processExitedEarly = true
-            }
-        }
-
-        try pythonProcess.run()
-
-        inputPipe = input
-        outputPipe = output
-        process = pythonProcess
-
-        try await Task.sleep(nanoseconds: 2_000_000_000)
-
-        if processExitedEarly || !pythonProcess.isRunning {
-            let exitCode = pythonProcess.terminationStatus
-            throw FluxError.modelLoadFailed("Python process exited early with code \(exitCode)")
-        }
-
-        isRunning = true
-    }
-
-    func shutdown() {
-        guard let proc = process, proc.isRunning else {
-            process = nil
-            inputPipe = nil
-            outputPipe = nil
-            isRunning = false
-            return
-        }
-
-        proc.terminate()
-        proc.waitUntilExit()
-
-        process = nil
-        inputPipe = nil
-        outputPipe = nil
-        isRunning = false
+    func shutdown() async {
+        await transport.shutdown()
     }
 }

--- a/Sources/AI/GemmaActor.swift
+++ b/Sources/AI/GemmaActor.swift
@@ -1,32 +1,6 @@
 import Foundation
 
-enum GemmaError: Error, LocalizedError {
-    case scriptNotFound
-    case processNotRunning
-    case malformedOutput
-    case timeout
-    case identificationFailed(String)
-    case modelLoadFailed(String)
-
-    var errorDescription: String? {
-        switch self {
-        case .scriptNotFound:
-            return " Gemma Python script not found. Expected at: \( GemmaActor.scriptPath)"
-        case .processNotRunning:
-            return "Gemma process is not running. Call restart() first."
-        case .malformedOutput:
-            return "Gemma returned malformed JSON. The model output could not be parsed."
-        case .timeout:
-            return "Gemma identification timed out after 300 seconds."
-        case .identificationFailed(let message):
-            return "Identification failed: \(message)"
-        case .modelLoadFailed(let message):
-            return "Failed to load Gemma model: \(message)"
-        }
-    }
-}
-
-struct IdentificationResult: Codable, Equatable {
+struct IdentificationResult: Codable, Equatable, Sendable {
     var kingdom: String
     var modelConfidence: String
     var topCandidate: TopCandidate
@@ -47,12 +21,10 @@ struct IdentificationResult: Codable, Equatable {
         case error
     }
 
-    // Legacy JSON (pre-multi-kingdom) has no `kingdom` key — default to plant
-    // so existing entries decode without migration.
+    // Legacy JSON (pre-multi-kingdom) has no `kingdom` key — Kingdom.parse
+    // handles that default and case-normalisation in one place.
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        // Default + normalisation lives in Kingdom.parse (legacy rows have no
-        // `kingdom` key; some payloads arrive title-cased).
         self.kingdom = Kingdom.parse(try c.decodeIfPresent(String.self, forKey: .kingdom)).rawValue
         self.modelConfidence = try c.decode(String.self, forKey: .modelConfidence)
         self.topCandidate = try c.decode(TopCandidate.self, forKey: .topCandidate)
@@ -64,7 +36,7 @@ struct IdentificationResult: Codable, Equatable {
     }
 }
 
-struct TopCandidate: Codable, Equatable {
+struct TopCandidate: Codable, Equatable, Sendable {
     var commonName: String
     var scientificName: String
     var family: String
@@ -76,7 +48,7 @@ struct TopCandidate: Codable, Equatable {
     }
 }
 
-struct Alternative: Codable, Equatable {
+struct Alternative: Codable, Equatable, Sendable {
     var commonName: String
     var scientificName: String
     var reason: String
@@ -90,176 +62,45 @@ struct Alternative: Codable, Equatable {
 
 actor GemmaActor {
     static let shared = GemmaActor()
-    static var scriptPath: String {
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        let naturista = appSupport.appendingPathComponent("Naturista", isDirectory: true)
-        let pythonDir = naturista.appendingPathComponent("Python", isDirectory: true)
-        return pythonDir.appendingPathComponent("gemma_service.py").path
+
+    private static var scriptPath: String {
+        AppPaths.applicationSupport
+            .appendingPathComponent("Python", isDirectory: true)
+            .appendingPathComponent("gemma_service.py")
+            .path
     }
 
-    private var process: Process?
-    private var inputPipe: Pipe?
-    private var outputPipe: Pipe?
-    private var isRunning = false
+    private let transport: PythonProcessTransport
 
-    private init() {}
+    private init() {
+        self.transport = PythonProcessTransport(config: .init(
+            scriptPath: GemmaActor.scriptPath,
+            environment: [
+                "GEMMA_MODEL_PATH": NSString(string: ModelConfig.gemmaPath).expandingTildeInPath
+            ],
+            timeoutSeconds: 310,
+            warmupSeconds: 2,
+            stderrLogURL: URL(fileURLWithPath: "/tmp/naturista_gemma.log")
+        ))
+    }
+
+    private struct IdentifyRequest: Encodable, Sendable {
+        let action: String
+        let photo_path: String
+    }
 
     func identify(photoPath: String) async throws -> IdentificationResult {
-        if process == nil || !isRunning {
-            try await restart()
+        let result = try await transport.call(
+            IdentifyRequest(action: "identify", photo_path: photoPath),
+            responseType: IdentificationResult.self
+        )
+        if let err = result.error, !err.isEmpty {
+            throw PythonRPCError.remote(err)
         }
-
-        guard let inputPipe = inputPipe, let outputPipe = outputPipe, isRunning else {
-            throw GemmaError.processNotRunning
-        }
-
-        let request: [String: Any] = [
-            "action": "identify",
-            "photo_path": photoPath
-        ]
-
-        guard let jsonData = try? JSONSerialization.data(withJSONObject: request, options: []),
-              let jsonString = String(data: jsonData, encoding: .utf8) else {
-            throw GemmaError.identificationFailed("Failed to encode request JSON")
-        }
-
-        inputPipe.writePipe.write(jsonString.appending("\n").data(using: .utf8)!)
-
-        var responseData = Data()
-        let timeoutTask = Task {
-            try await Task.sleep(nanoseconds: 310_000_000_000)
-            throw GemmaError.timeout
-        }
-
-        let readTask = Task {
-            while true {
-                try await Task.sleep(nanoseconds: 100_000_000)
-                let available = outputPipe.readPipe.availableData
-                if !available.isEmpty {
-                    responseData.append(available)
-                    if let responseString = String(data: responseData, encoding: .utf8),
-                       responseString.contains("\n") {
-                        let lines = responseString.components(separatedBy: "\n")
-                        if let firstLine = lines.first(where: { !$0.isEmpty }) {
-                            return firstLine
-                        }
-                    }
-                }
-            }
-        }
-
-        var resultString: String?
-        do {
-            resultString = try await readTask.value
-            timeoutTask.cancel()
-        } catch {
-            readTask.cancel()
-            timeoutTask.cancel()
-            try? await restart()
-            throw error
-        }
-
-        guard let result = resultString else {
-            throw GemmaError.malformedOutput
-        }
-
-        guard let data = result.data(using: .utf8) else {
-            throw GemmaError.malformedOutput
-        }
-
-        do {
-            let decoder = JSONDecoder()
-            var identification = try decoder.decode(IdentificationResult.self, from: data)
-
-            if let errorMessage = identification.error, !errorMessage.isEmpty {
-                throw GemmaError.identificationFailed(errorMessage)
-            }
-
-            return identification
-        } catch let error as GemmaError {
-            throw error
-        } catch {
-            if result.contains("\"error\"") {
-                if let errorData = result.data(using: .utf8),
-                   let errorJson = try? JSONSerialization.jsonObject(with: errorData) as? [String: Any],
-                   let errorMessage = errorJson["error"] as? String {
-                    throw GemmaError.identificationFailed(errorMessage)
-                }
-            }
-            throw GemmaError.malformedOutput
-        }
+        return result
     }
 
-    func restart() async throws {
-        await shutdown()
-
-        let scriptPath = GemmaActor.scriptPath
-        guard FileManager.default.fileExists(atPath: scriptPath) else {
-            throw GemmaError.scriptNotFound
-        }
-
-        let pythonProcess = Process()
-        pythonProcess.executableURL = URL(fileURLWithPath: NSString(string: ModelConfig.pythonPath).expandingTildeInPath)
-        pythonProcess.arguments = [scriptPath]
-
-        let input = Pipe()
-        let output = Pipe()
-        pythonProcess.standardOutput = output
-        pythonProcess.standardInput = input
-        let stderrLogPath = "/tmp/naturista_gemma.log"
-        FileManager.default.createFile(atPath: stderrLogPath, contents: nil)
-        pythonProcess.standardError = FileHandle(forWritingAtPath: stderrLogPath) ?? FileHandle.nullDevice
-
-        let errorPipe = Pipe()
-        pythonProcess.environment = [
-            "PYNO_SHOW_ASSET_WARNING": "1",
-            "PYTHONUNBUFFERED": "1",
-            "GEMMA_MODEL_PATH": NSString(string: ModelConfig.gemmaPath).expandingTildeInPath
-        ]
-
-        var processExitedEarly = false
-        pythonProcess.terminationHandler = { proc in
-            if proc.terminationStatus != 0 {
-                processExitedEarly = true
-            }
-        }
-
-        try pythonProcess.run()
-
-        inputPipe = input
-        outputPipe = output
-        process = pythonProcess
-
-        try await Task.sleep(nanoseconds: 2_000_000_000)
-
-        if processExitedEarly || !pythonProcess.isRunning {
-            let exitCode = pythonProcess.terminationStatus
-            throw GemmaError.modelLoadFailed("Python process exited early with code \(exitCode)")
-        }
-
-        isRunning = true
+    func shutdown() async {
+        await transport.shutdown()
     }
-
-    func shutdown() {
-        guard let proc = process, proc.isRunning else {
-            process = nil
-            inputPipe = nil
-            outputPipe = nil
-            isRunning = false
-            return
-        }
-
-        proc.terminate()
-        proc.waitUntilExit()
-
-        process = nil
-        inputPipe = nil
-        outputPipe = nil
-        isRunning = false
-    }
-}
-
-extension Pipe {
-    var readPipe: FileHandle { fileHandleForReading }
-    var writePipe: FileHandle { fileHandleForWriting }
 }

--- a/Sources/AI/GemmaActor.swift
+++ b/Sources/AI/GemmaActor.swift
@@ -26,7 +26,7 @@ enum GemmaError: Error, LocalizedError {
     }
 }
 
-struct IdentificationResult: Codable {
+struct IdentificationResult: Codable, Equatable {
     var kingdom: String
     var modelConfidence: String
     var topCandidate: TopCandidate
@@ -51,7 +51,9 @@ struct IdentificationResult: Codable {
     // so existing entries decode without migration.
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        self.kingdom = (try c.decodeIfPresent(String.self, forKey: .kingdom)) ?? "plant"
+        // Default + normalisation lives in Kingdom.parse (legacy rows have no
+        // `kingdom` key; some payloads arrive title-cased).
+        self.kingdom = Kingdom.parse(try c.decodeIfPresent(String.self, forKey: .kingdom)).rawValue
         self.modelConfidence = try c.decode(String.self, forKey: .modelConfidence)
         self.topCandidate = try c.decode(TopCandidate.self, forKey: .topCandidate)
         self.alternatives = (try c.decodeIfPresent([Alternative].self, forKey: .alternatives)) ?? []
@@ -62,7 +64,7 @@ struct IdentificationResult: Codable {
     }
 }
 
-struct TopCandidate: Codable {
+struct TopCandidate: Codable, Equatable {
     var commonName: String
     var scientificName: String
     var family: String
@@ -74,7 +76,7 @@ struct TopCandidate: Codable {
     }
 }
 
-struct Alternative: Codable {
+struct Alternative: Codable, Equatable {
     var commonName: String
     var scientificName: String
     var reason: String

--- a/Sources/AI/ModelLease.swift
+++ b/Sources/AI/ModelLease.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+// Encodes the "only one model holds GPU memory at a time" rule as an
+// invariant rather than something every caller has to remember. Any work
+// that wants exclusive access to one tenant shuts down the *other* warm
+// tenant on entry.
+
+enum ModelLeaseTenant: Sendable {
+    case identification   // Gemma
+    case illustration     // Flux
+}
+
+actor ModelLease {
+    static let shared = ModelLease()
+
+    private var current: ModelLeaseTenant?
+
+    func withExclusive<T: Sendable>(
+        _ tenant: ModelLeaseTenant,
+        _ work: () async throws -> T
+    ) async throws -> T {
+        if let other = current, other != tenant {
+            await release(other)
+        }
+        current = tenant
+        return try await work()
+    }
+
+    private func release(_ tenant: ModelLeaseTenant) async {
+        switch tenant {
+        case .identification: await GemmaActor.shared.shutdown()
+        case .illustration:   await FluxActor.shared.shutdown()
+        }
+    }
+}

--- a/Sources/AI/PythonRPCTransport.swift
+++ b/Sources/AI/PythonRPCTransport.swift
@@ -1,0 +1,257 @@
+import Foundation
+
+// Long-lived Python subprocess speaking JSON-line RPC over stdin/stdout.
+// Replaces the duplicated process-lifecycle / IPC machinery that lived in
+// FluxActor and GemmaActor. Per-model wrappers shrink to typed Codable
+// adapters that only declare their request/response shapes.
+
+enum PythonRPCError: Error, LocalizedError {
+    case scriptNotFound(String)
+    case modelLoadFailed(String)
+    case processNotRunning
+    case timeout(seconds: TimeInterval)
+    case malformedOutput(String)
+    case remote(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .scriptNotFound(let path):
+            return "Python script not found at \(path)."
+        case .modelLoadFailed(let m):
+            return "Failed to load Python model process: \(m)"
+        case .processNotRunning:
+            return "Python process is not running."
+        case .timeout(let s):
+            return "Python RPC timed out after \(Int(s)) seconds."
+        case .malformedOutput(let m):
+            return "Python returned malformed output: \(m)"
+        case .remote(let m):
+            return m
+        }
+    }
+}
+
+// Subprocess seam — a stand-in is injected from tests so the transport's
+// state machine is exercisable without spawning real Python.
+protocol RPCSubprocess: AnyObject {
+    var isRunning: Bool { get }
+    func send(_ line: String) throws
+    func readLine(timeoutSeconds: TimeInterval) async throws -> String?
+    func terminate()
+}
+
+struct ProcessFactory: @unchecked Sendable {
+    var make: (_ executable: URL,
+               _ arguments: [String],
+               _ environment: [String: String],
+               _ stderrLogURL: URL) throws -> any RPCSubprocess
+
+    static let live = ProcessFactory { executable, args, env, stderrURL in
+        try LivePythonSubprocess(
+            executable: executable,
+            arguments: args,
+            environment: env,
+            stderrLogURL: stderrURL
+        )
+    }
+}
+
+// MARK: - Transport
+
+protocol PythonRPCTransport: Actor {
+    func call<Request: Encodable & Sendable, Response: Decodable & Sendable>(
+        _ request: Request,
+        responseType: Response.Type
+    ) async throws -> Response
+
+    func shutdown() async
+}
+
+actor PythonProcessTransport: PythonRPCTransport {
+    struct Config: Sendable {
+        let scriptPath: String
+        let environment: [String: String]
+        let timeoutSeconds: TimeInterval
+        let warmupSeconds: TimeInterval
+        let stderrLogURL: URL
+    }
+
+    private let config: Config
+    private let factory: ProcessFactory
+    private var subprocess: (any RPCSubprocess)?
+
+    init(config: Config, factory: ProcessFactory = .live) {
+        self.config = config
+        self.factory = factory
+    }
+
+    func call<Request: Encodable & Sendable, Response: Decodable & Sendable>(
+        _ request: Request,
+        responseType: Response.Type
+    ) async throws -> Response {
+        if subprocess == nil || subprocess?.isRunning != true {
+            try await restart()
+        }
+        guard let sub = subprocess else { throw PythonRPCError.processNotRunning }
+
+        let body: String
+        do {
+            let data = try JSONEncoder().encode(request)
+            guard let s = String(data: data, encoding: .utf8) else {
+                throw PythonRPCError.malformedOutput("Could not encode request.")
+            }
+            body = s
+        } catch let e as PythonRPCError {
+            throw e
+        } catch {
+            throw PythonRPCError.malformedOutput(error.localizedDescription)
+        }
+
+        do {
+            try sub.send(body)
+        } catch {
+            await teardown()
+            throw error
+        }
+
+        let line: String?
+        do {
+            line = try await sub.readLine(timeoutSeconds: config.timeoutSeconds)
+        } catch {
+            await teardown()
+            throw error
+        }
+
+        guard let line, let lineData = line.data(using: .utf8) else {
+            await teardown()
+            throw PythonRPCError.timeout(seconds: config.timeoutSeconds)
+        }
+
+        // Try the typed decode. If that fails, see whether the payload is a
+        // {"error": "..."} envelope so we surface the real cause instead of a
+        // malformed-output message.
+        do {
+            return try JSONDecoder().decode(Response.self, from: lineData)
+        } catch let typedError {
+            if let object = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+               let errMessage = object["error"] as? String {
+                await teardown()
+                throw PythonRPCError.remote(errMessage)
+            }
+            await teardown()
+            throw PythonRPCError.malformedOutput(typedError.localizedDescription)
+        }
+    }
+
+    func shutdown() async {
+        await teardown()
+    }
+
+    private func teardown() async {
+        subprocess?.terminate()
+        subprocess = nil
+    }
+
+    private func restart() async throws {
+        await teardown()
+
+        guard FileManager.default.fileExists(atPath: config.scriptPath) else {
+            throw PythonRPCError.scriptNotFound(config.scriptPath)
+        }
+
+        let executableURL = URL(fileURLWithPath: NSString(string: ModelConfig.pythonPath).expandingTildeInPath)
+
+        var env = config.environment
+        env["PYTHONUNBUFFERED"] = "1"
+
+        let sub: any RPCSubprocess
+        do {
+            sub = try factory.make(executableURL, [config.scriptPath], env, config.stderrLogURL)
+        } catch {
+            throw PythonRPCError.modelLoadFailed(error.localizedDescription)
+        }
+
+        // Warmup gate — give the model a moment to load weights, then check the
+        // process is still alive before declaring it ready.
+        try await Task.sleep(nanoseconds: UInt64(config.warmupSeconds * 1_000_000_000))
+
+        guard sub.isRunning else {
+            throw PythonRPCError.modelLoadFailed("Python process exited during warmup.")
+        }
+
+        subprocess = sub
+    }
+}
+
+// MARK: - Live subprocess (production)
+
+private final class LivePythonSubprocess: RPCSubprocess, @unchecked Sendable {
+    private let process: Process
+    private let inputPipe: Pipe
+    private let outputPipe: Pipe
+
+    init(executable: URL, arguments: [String], environment: [String: String], stderrLogURL: URL) throws {
+        process = Process()
+        process.executableURL = executable
+        process.arguments = arguments
+        process.environment = environment
+
+        inputPipe = Pipe()
+        outputPipe = Pipe()
+        process.standardInput = inputPipe
+        process.standardOutput = outputPipe
+
+        FileManager.default.createFile(atPath: stderrLogURL.path, contents: nil)
+        process.standardError = FileHandle(forWritingAtPath: stderrLogURL.path) ?? FileHandle.nullDevice
+
+        try process.run()
+    }
+
+    var isRunning: Bool { process.isRunning }
+
+    func send(_ line: String) throws {
+        guard let data = (line + "\n").data(using: .utf8) else {
+            throw PythonRPCError.malformedOutput("Could not encode request line.")
+        }
+        try inputPipe.fileHandleForWriting.write(contentsOf: data)
+    }
+
+    // 100ms poll on `availableData`, accumulate into a buffer, return the
+    // first non-empty line ending in `\n` or nil on timeout. Mirrors the
+    // original Flux/Gemma read loop.
+    func readLine(timeoutSeconds: TimeInterval) async throws -> String? {
+        var buffer = Data()
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        while !Task.isCancelled {
+            try Task.checkCancellation()
+            let available = outputPipe.fileHandleForReading.availableData
+            if !available.isEmpty {
+                buffer.append(available)
+                if let s = String(data: buffer, encoding: .utf8),
+                   let nl = s.firstIndex(of: "\n") {
+                    let line = String(s[..<nl])
+                    if !line.isEmpty { return line }
+                    // Skip a leading blank line and keep reading.
+                    let after = s.index(after: nl)
+                    buffer = Data(String(s[after...]).utf8)
+                }
+            }
+            if Date() >= deadline { return nil }
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+        return nil
+    }
+
+    func terminate() {
+        guard process.isRunning else { return }
+        process.terminate()
+        process.waitUntilExit()
+    }
+}
+
+// Single home for the Pipe extensions previously duplicated across
+// FluxActor and GemmaActor. Only LivePythonSubprocess uses them now.
+extension Pipe {
+    var readPipe: FileHandle { fileHandleForReading }
+    var writePipe: FileHandle { fileHandleForWriting }
+}

--- a/Sources/Models/Entry.swift
+++ b/Sources/Models/Entry.swift
@@ -23,6 +23,17 @@ struct Entry: Codable, FetchableRecord, PersistableRecord, Identifiable {
     }
 }
 
+extension Entry {
+    var identification: Identification {
+        Identification.parse(identificationJson)
+    }
+
+    mutating func setIdentification(_ id: Identification) {
+        identificationJson = id.encodedJSON()
+        modelConfidence = id.modelConfidence
+    }
+}
+
 // Pre-kingdom-aware entries (all plants) have no `kingdom` key in their
 // identificationJson. `parse(_:)` defaults to .plant so legacy rows render
 // correctly with no migration.

--- a/Sources/Models/Identification.swift
+++ b/Sources/Models/Identification.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+// Typed view over Entry.identificationJson. Collapses the three storage
+// shapes ("", {"error":"..."}, full IdentificationResult JSON) into one
+// Status enum, and centralises the "missing kingdom defaults to plant"
+// rule for legacy rows.
+struct Identification: Equatable {
+    enum Status: Equatable {
+        case pending
+        case failed(message: String)
+        case ready(IdentificationResult)
+    }
+
+    let status: Status
+
+    static func success(_ result: IdentificationResult) -> Identification {
+        Identification(status: .ready(result))
+    }
+
+    static func failure(_ message: String) -> Identification {
+        Identification(status: .failed(message: message))
+    }
+
+    static let pending = Identification(status: .pending)
+}
+
+extension Identification {
+    var result: IdentificationResult? {
+        if case .ready(let r) = status { return r }
+        return nil
+    }
+
+    var failureMessage: String? {
+        if case .failed(let m) = status { return m }
+        return nil
+    }
+
+    var commonName: String?    { result?.topCandidate.commonName }
+    var scientificName: String? { result?.topCandidate.scientificName }
+    var family: String?        { result?.topCandidate.family }
+    var kingdom: Kingdom       { result.map { Kingdom.parse($0.kingdom) } ?? .plant }
+    var modelConfidence: String? { result?.modelConfidence }
+    var visibleEvidence: [String] { result?.visibleEvidence ?? [] }
+    var alternatives: [Alternative] { result?.alternatives ?? [] }
+}
+
+// MARK: - Parsing & encoding
+
+extension Identification {
+    // Parses the three legal payload shapes. Cached by JSON string so each
+    // unique payload decodes exactly once across the app lifetime — the
+    // LibraryView search filter would otherwise re-parse N entries per
+    // keystroke.
+    static func parse(_ json: String) -> Identification {
+        if json.isEmpty { return .pending }
+        if let cached = IdentificationCache.shared.value(for: json) {
+            return cached
+        }
+        let parsed = decode(json)
+        IdentificationCache.shared.set(parsed, for: json)
+        return parsed
+    }
+
+    private static func decode(_ json: String) -> Identification {
+        guard let data = json.data(using: .utf8) else {
+            return .failure("Could not read identification payload.")
+        }
+        // Error payloads ({"error":"..."}) are emitted by the import/pipeline
+        // failure paths. Try them before the structured decode so a malformed
+        // IdentificationResult never masks a real error message.
+        if let errorJson = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let errorMessage = errorJson["error"] as? String,
+           errorJson["top_candidate"] == nil {
+            return .failure(errorMessage)
+        }
+        do {
+            let result = try JSONDecoder().decode(IdentificationResult.self, from: data)
+            if let err = result.error, !err.isEmpty {
+                return .failure(err)
+            }
+            return .success(result)
+        } catch {
+            return .failure("Could not decode identification: \(error.localizedDescription)")
+        }
+    }
+
+    // Encodes the identification to the JSON shape stored in `Entry.identificationJson`.
+    func encodedJSON() -> String {
+        switch status {
+        case .pending:
+            return ""
+        case .failed(let message):
+            let payload = ["error": message]
+            guard let data = try? JSONSerialization.data(withJSONObject: payload, options: []),
+                  let s = String(data: data, encoding: .utf8) else {
+                return "{\"error\":\"identification failed\"}"
+            }
+            return s
+        case .ready(let result):
+            guard let data = try? JSONEncoder().encode(result),
+                  let s = String(data: data, encoding: .utf8) else {
+                return ""
+            }
+            return s
+        }
+    }
+}
+
+// Reference-typed cache so reading from a struct doesn't require mutation,
+// and so two Entry copies of the same row share the parsed result. NSCache
+// auto-evicts under memory pressure.
+private final class IdentificationCache {
+    static let shared = IdentificationCache()
+
+    private let cache = NSCache<NSString, CacheEntry>()
+
+    private final class CacheEntry {
+        let value: Identification
+        init(_ value: Identification) { self.value = value }
+    }
+
+    func value(for json: String) -> Identification? {
+        cache.object(forKey: json as NSString)?.value
+    }
+
+    func set(_ value: Identification, for json: String) {
+        cache.setObject(CacheEntry(value), forKey: json as NSString)
+    }
+}

--- a/Sources/Services/PhotoImportService.swift
+++ b/Sources/Services/PhotoImportService.swift
@@ -31,7 +31,9 @@ actor PhotoImportService {
 
         let workingPath = AppPaths.working.appendingPathComponent(workingFilename).path
         do {
-            let identification = try await GemmaActor.shared.identify(photoPath: workingPath)
+            let identification = try await ModelLease.shared.withExclusive(.identification) {
+                try await GemmaActor.shared.identify(photoPath: workingPath)
+            }
             entry.setIdentification(.success(identification))
             try await DatabaseService.shared.saveEntry(entry)
         } catch {

--- a/Sources/Services/PhotoImportService.swift
+++ b/Sources/Services/PhotoImportService.swift
@@ -32,13 +32,10 @@ actor PhotoImportService {
         let workingPath = AppPaths.working.appendingPathComponent(workingFilename).path
         do {
             let identification = try await GemmaActor.shared.identify(photoPath: workingPath)
-            let encoder = JSONEncoder()
-            entry.identificationJson = String(data: try encoder.encode(identification), encoding: .utf8) ?? ""
-            entry.modelConfidence = identification.modelConfidence
+            entry.setIdentification(.success(identification))
             try await DatabaseService.shared.saveEntry(entry)
         } catch {
-            let encoder = JSONEncoder()
-            entry.identificationJson = String(data: try encoder.encode(["error": error.localizedDescription]), encoding: .utf8) ?? ""
+            entry.setIdentification(.failure(error.localizedDescription))
             entry.userStatus = "failed"
             try await DatabaseService.shared.saveEntry(entry)
         }

--- a/Sources/Services/PipelineService.swift
+++ b/Sources/Services/PipelineService.swift
@@ -61,14 +61,14 @@ actor PipelineService {
 
         let workingPath = AppPaths.working.appendingPathComponent(currentEntry.workingImageFilename).path
 
-        await GemmaActor.shared.shutdown()
-
         do {
-            let illustrationPath = try await FluxActor.shared.generate(
-                photoPath: workingPath,
-                identification: identification,
-                entryId: entryId
-            )
+            let illustrationPath = try await ModelLease.shared.withExclusive(.illustration) {
+                try await FluxActor.shared.generate(
+                    photoPath: workingPath,
+                    identification: identification,
+                    entryId: entryId
+                )
+            }
             print("[regenerate] FluxActor returned path=\(illustrationPath)")
             let attrs = try? FileManager.default.attributesOfItem(atPath: illustrationPath)
             let size = (attrs?[.size] as? Int) ?? -1
@@ -77,10 +77,8 @@ actor PipelineService {
             currentEntry.illustrationFilename = URL(fileURLWithPath: illustrationPath).lastPathComponent
             try await DatabaseService.shared.saveEntry(currentEntry)
             print("[regenerate] saved illustrationFilename=\(currentEntry.illustrationFilename ?? "<nil>")")
-            await FluxActor.shared.shutdown()
         } catch {
             print("[regenerate] error: \(error)")
-            await FluxActor.shared.shutdown()
             throw PipelineError.fluxFailed(error.localizedDescription)
         }
     }
@@ -99,20 +97,18 @@ actor PipelineService {
             throw PipelineError.gemmaFailed("Entry has no valid identification.")
         }
 
-        await GemmaActor.shared.shutdown()
-
         do {
-            let illustrationPath = try await FluxActor.shared.generate(
-                photoPath: workingPath,
-                identification: identification,
-                entryId: entryId
-            )
+            let illustrationPath = try await ModelLease.shared.withExclusive(.illustration) {
+                try await FluxActor.shared.generate(
+                    photoPath: workingPath,
+                    identification: identification,
+                    entryId: entryId
+                )
+            }
             currentEntry.illustrationFilename = URL(fileURLWithPath: illustrationPath).lastPathComponent
             currentEntry.userStatus = "unreviewed"
             try await DatabaseService.shared.saveEntry(currentEntry)
-            await FluxActor.shared.shutdown()
         } catch {
-            await FluxActor.shared.shutdown()
             currentEntry.userStatus = "failed"
             currentEntry.notes = "FLUX generation failed: \(error.localizedDescription)"
             try await DatabaseService.shared.saveEntry(currentEntry)
@@ -129,7 +125,9 @@ actor PipelineService {
 
         let identification: IdentificationResult
         do {
-            let result = try await GemmaActor.shared.identify(photoPath: workingPath)
+            let result = try await ModelLease.shared.withExclusive(.identification) {
+                try await GemmaActor.shared.identify(photoPath: workingPath)
+            }
             currentEntry.setIdentification(.success(result))
             try await DatabaseService.shared.saveEntry(currentEntry)
             identification = result
@@ -140,20 +138,18 @@ actor PipelineService {
             throw PipelineError.gemmaFailed(error.localizedDescription)
         }
 
-        await GemmaActor.shared.shutdown()
-
         do {
-            let illustrationPath = try await FluxActor.shared.generate(
-                photoPath: workingPath,
-                identification: identification,
-                entryId: entryId
-            )
+            let illustrationPath = try await ModelLease.shared.withExclusive(.illustration) {
+                try await FluxActor.shared.generate(
+                    photoPath: workingPath,
+                    identification: identification,
+                    entryId: entryId
+                )
+            }
             currentEntry.illustrationFilename = URL(fileURLWithPath: illustrationPath).lastPathComponent
             currentEntry.userStatus = "unreviewed"
             try await DatabaseService.shared.saveEntry(currentEntry)
-            await FluxActor.shared.shutdown()
         } catch {
-            await FluxActor.shared.shutdown()
             currentEntry.userStatus = "failed"
             currentEntry.notes = "FLUX generation failed: \(error.localizedDescription)"
             try await DatabaseService.shared.saveEntry(currentEntry)

--- a/Sources/Services/PipelineService.swift
+++ b/Sources/Services/PipelineService.swift
@@ -55,11 +55,8 @@ actor PipelineService {
         }
         print("[regenerate] existing illustrationFilename=\(currentEntry.illustrationFilename ?? "<nil>")")
 
-        let identification: IdentificationResult
-        do {
-            identification = try JSONDecoder().decode(IdentificationResult.self, from: Data(currentEntry.identificationJson.utf8))
-        } catch {
-            throw PipelineError.gemmaFailed("Entry has no valid identification: \(error.localizedDescription)")
+        guard let identification = currentEntry.identification.result else {
+            throw PipelineError.gemmaFailed("Entry has no valid identification.")
         }
 
         let workingPath = AppPaths.working.appendingPathComponent(currentEntry.workingImageFilename).path
@@ -98,11 +95,8 @@ actor PipelineService {
 
         let workingPath = AppPaths.working.appendingPathComponent(currentEntry.workingImageFilename).path
 
-        let identification: IdentificationResult
-        do {
-            identification = try JSONDecoder().decode(IdentificationResult.self, from: Data(currentEntry.identificationJson.utf8))
-        } catch {
-            throw PipelineError.gemmaFailed("Entry has no valid identification: \(error.localizedDescription)")
+        guard let identification = currentEntry.identification.result else {
+            throw PipelineError.gemmaFailed("Entry has no valid identification.")
         }
 
         await GemmaActor.shared.shutdown()
@@ -136,8 +130,7 @@ actor PipelineService {
         let identification: IdentificationResult
         do {
             let result = try await GemmaActor.shared.identify(photoPath: workingPath)
-            currentEntry.identificationJson = String(data: try JSONEncoder().encode(result), encoding: .utf8) ?? ""
-            currentEntry.modelConfidence = result.modelConfidence
+            currentEntry.setIdentification(.success(result))
             try await DatabaseService.shared.saveEntry(currentEntry)
             identification = result
         } catch {

--- a/Sources/Views/EntryDetailView.swift
+++ b/Sources/Views/EntryDetailView.swift
@@ -164,14 +164,15 @@ struct EntryDetailView: View {
     // MARK: - Side panel
 
     private var sidePanel: some View {
-        VStack(alignment: .leading, spacing: 28) {
+        let id = entry.identification
+        return VStack(alignment: .leading, spacing: 28) {
             VStack(alignment: .leading, spacing: 4) {
                 Eyebrow(text: "Identification")
-                Text(entry.commonName)
+                Text(id.commonName ?? "Unidentified")
                     .font(DS.serif(26, weight: .regular))
                     .foregroundColor(DS.ink)
-                if !entry.scientificName.isEmpty {
-                    Text(entry.scientificName)
+                if let scientific = id.scientificName, !scientific.isEmpty {
+                    Text(scientific)
                         .font(DS.serif(15, italic: true))
                         .foregroundColor(DS.inkSoft)
                 }
@@ -180,7 +181,8 @@ struct EntryDetailView: View {
             VStack(alignment: .leading, spacing: 0) {
                 Hairline(color: DS.hairline)
                 detailRow(label: "Family") {
-                    Text(entry.family.isEmpty ? "—" : entry.family)
+                    let family = id.family ?? ""
+                    Text(family.isEmpty ? "—" : family)
                         .font(DS.serif(13, italic: true))
                         .foregroundColor(DS.ink)
                 }
@@ -204,18 +206,18 @@ struct EntryDetailView: View {
                 }
             }
 
-            if !visibleEvidence.isEmpty {
+            if !id.visibleEvidence.isEmpty {
                 VStack(alignment: .leading, spacing: 10) {
-                    Eyebrow(text: entry.kingdom.visibleEvidenceLabel)
-                    FlowingTags(tags: visibleEvidence)
+                    Eyebrow(text: id.kingdom.visibleEvidenceLabel)
+                    FlowingTags(tags: id.visibleEvidence)
                 }
             }
 
-            if !alternatives.isEmpty {
+            if !id.alternatives.isEmpty {
                 VStack(alignment: .leading, spacing: 10) {
                     Eyebrow(text: "Alternatives")
                     VStack(alignment: .leading, spacing: 12) {
-                        ForEach(Array(alternatives.enumerated()), id: \.offset) { _, alt in
+                        ForEach(Array(id.alternatives.enumerated()), id: \.offset) { _, alt in
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(alt.commonName)
                                     .font(DS.sans(13))
@@ -272,7 +274,7 @@ struct EntryDetailView: View {
                         }
                     }
                     .buttonStyle(QuietButtonStyle())
-                    .disabled(entry.identificationJson.isEmpty || isRetrying || isRecomposing || isDeleting)
+                    .disabled(entry.identification.result == nil || isRetrying || isRecomposing || isDeleting)
                 }
                 Button(role: .destructive) { showDeleteConfirm = true } label: {
                     HStack(spacing: 6) {
@@ -344,24 +346,11 @@ struct EntryDetailView: View {
         return f.string(from: d)
     }
 
-    private struct AlternativeRow {
-        let commonName: String
-        let scientificName: String
-        let reason: String
-    }
-
-    private var visibleEvidence: [String] {
-        guard let data = entry.identificationJson.data(using: .utf8),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let evidence = json["visible_evidence"] as? [String] else { return [] }
-        return evidence
-    }
-
     // Kingdom-specific safety boilerplate for the panel footer. The fungus
     // case bolds "Never eat" — mushroom misidentification has lethal stakes
     // and a polite hedge would undersell that.
     private var safetyFooter: Text {
-        switch entry.kingdom {
+        switch entry.identification.kingdom {
         case .plant:
             return Text("Identification produced locally. Treat as a reference — verify with a field guide before consumption or handling.")
         case .animal:
@@ -375,23 +364,10 @@ struct EntryDetailView: View {
         }
     }
 
-    private var alternatives: [AlternativeRow] {
-        guard let data = entry.identificationJson.data(using: .utf8),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let alts = json["alternatives"] as? [[String: Any]] else { return [] }
-        return alts.map { row in
-            AlternativeRow(
-                commonName: row["common_name"] as? String ?? "",
-                scientificName: row["scientific_name"] as? String ?? "",
-                reason: row["reason"] as? String ?? ""
-            )
-        }
-    }
-
     // MARK: - Side effects
 
     private func updateWindowTitle() {
-        NSApp.windows.first?.title = "Naturista — \(entry.commonName)"
+        NSApp.windows.first?.title = "Naturista — \(entry.identification.commonName ?? "Entry")"
     }
 
     private func persistEntry() {
@@ -481,7 +457,7 @@ struct EntryDetailView: View {
         let panel = NSSavePanel()
         panel.title = "Export Plate"
         panel.allowedContentTypes = [.png]
-        panel.nameFieldStringValue = "\(entry.commonName)-plate.png"
+        panel.nameFieldStringValue = "\(entry.identification.commonName ?? "plate")-plate.png"
         panel.canCreateDirectories = true
 
         guard panel.runModal() == .OK, let destination = panel.url else {
@@ -564,7 +540,7 @@ private struct NotesEditor: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             Eyebrow(text: "Notes")
-            Text(entry.commonName)
+            Text(entry.identification.commonName ?? "Notes")
                 .font(DS.serif(22))
                 .foregroundColor(DS.ink)
 

--- a/Sources/Views/EntryRowView.swift
+++ b/Sources/Views/EntryRowView.swift
@@ -7,6 +7,7 @@ struct EntryRowView: View {
     @State private var hovered = false
 
     var body: some View {
+        let id = entry.identification
         VStack(alignment: .leading, spacing: 0) {
             ZStack(alignment: .topLeading) {
                 Rectangle()
@@ -27,20 +28,20 @@ struct EntryRowView: View {
                     Rectangle()
                         .fill(DS.hairline)
                         .frame(width: 1, height: 9)
-                    MonoLabel(text: entry.kingdom.displayLabel, color: DS.muted)
+                    MonoLabel(text: id.kingdom.displayLabel, color: DS.muted)
                 }
                 .padding(.horizontal, 12)
                 .padding(.vertical, 10)
             }
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(entry.commonName)
+                Text(id.commonName ?? "Unidentified")
                     .font(DS.serif(17, weight: .regular))
                     .foregroundColor(DS.ink)
                     .lineLimit(2)
                     .fixedSize(horizontal: false, vertical: true)
-                if !entry.scientificName.isEmpty {
-                    Text(entry.scientificName)
+                if let scientific = id.scientificName, !scientific.isEmpty {
+                    Text(scientific)
                         .font(DS.serif(13, italic: true))
                         .foregroundColor(DS.mutedDeep)
                         .lineLimit(1)
@@ -76,10 +77,11 @@ struct EntryRowView: View {
     @ViewBuilder
     private var workingOrPlaceholder: some View {
         let workingURL = AppPaths.working.appendingPathComponent(entry.workingImageFilename)
+        let label = entry.identification.commonName ?? "Unidentified"
         if FileManager.default.fileExists(atPath: workingURL.path) {
-            LocalImage(url: workingURL, contentMode: .fill, fallback: { PlatePlaceholder(label: entry.commonName) })
+            LocalImage(url: workingURL, contentMode: .fill, fallback: { PlatePlaceholder(label: label) })
         } else {
-            PlatePlaceholder(label: entry.commonName)
+            PlatePlaceholder(label: label)
         }
     }
 
@@ -134,42 +136,3 @@ struct LocalImage<Fallback: View>: View {
     }
 }
 
-extension Entry {
-    var commonName: String {
-        guard let data = self.identificationJson.data(using: .utf8),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let topCandidate = json["top_candidate"] as? [String: Any],
-              let name = topCandidate["common_name"] as? String else {
-            return "Unidentified"
-        }
-        return name
-    }
-
-    var scientificName: String {
-        guard let data = self.identificationJson.data(using: .utf8),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let topCandidate = json["top_candidate"] as? [String: Any],
-              let name = topCandidate["scientific_name"] as? String else {
-            return ""
-        }
-        return name
-    }
-
-    var family: String {
-        guard let data = self.identificationJson.data(using: .utf8),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let topCandidate = json["top_candidate"] as? [String: Any],
-              let fam = topCandidate["family"] as? String else {
-            return ""
-        }
-        return fam
-    }
-
-    var kingdom: Kingdom {
-        guard let data = self.identificationJson.data(using: .utf8),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            return .plant
-        }
-        return Kingdom.parse(json["kingdom"] as? String)
-    }
-}

--- a/Sources/Views/ImportFlowView.swift
+++ b/Sources/Views/ImportFlowView.swift
@@ -231,21 +231,18 @@ struct ImportFlowView: View {
                 let entry = try await PhotoImportService.shared.importPhoto(from: url)
                 await MainActor.run { self.entry = entry }
 
-                let decoder = JSONDecoder()
-                if let data = entry.identificationJson.data(using: .utf8),
-                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                   let _ = json["error"] {
-                    await MainActor.run {
-                        identificationError = json["error"] as? String ?? "Identification failed."
-                        stage = .identified
-                    }
-                } else if !entry.identificationJson.isEmpty {
-                    let result = try decoder.decode(IdentificationResult.self, from: Data(entry.identificationJson.utf8))
+                switch entry.identification.status {
+                case .ready(let result):
                     await MainActor.run {
                         identification = result
                         stage = .identified
                     }
-                } else {
+                case .failed(let message):
+                    await MainActor.run {
+                        identificationError = message
+                        stage = .identified
+                    }
+                case .pending:
                     await MainActor.run {
                         identificationError = "The model returned no identification."
                         stage = .identified

--- a/Sources/Views/LibraryView.swift
+++ b/Sources/Views/LibraryView.swift
@@ -15,12 +15,16 @@ struct LibraryView: View {
 
     private var filtered: [Entry] {
         entries.filter { e in
-            if let fam = activeFamily, e.family != fam { return false }
+            let id = e.identification
+            let family = id.family ?? ""
+            if let fam = activeFamily, family != fam { return false }
             if query.isEmpty { return true }
             let q = query.lowercased()
-            return e.commonName.lowercased().contains(q)
-                || e.scientificName.lowercased().contains(q)
-                || e.family.lowercased().contains(q)
+            let common = id.commonName ?? ""
+            let scientific = id.scientificName ?? ""
+            return common.lowercased().contains(q)
+                || scientific.lowercased().contains(q)
+                || family.lowercased().contains(q)
         }
     }
 
@@ -37,8 +41,9 @@ struct LibraryView: View {
 
     private var familyCounts: [(String, Int)] {
         var counts: [String: Int] = [:]
-        for e in entries where !e.family.isEmpty {
-            counts[e.family, default: 0] += 1
+        for e in entries {
+            guard let family = e.identification.family, !family.isEmpty else { continue }
+            counts[family, default: 0] += 1
         }
         return counts.sorted { lhs, rhs in
             if lhs.value != rhs.value { return lhs.value > rhs.value }
@@ -178,7 +183,7 @@ struct LibraryView: View {
                     HStack(spacing: 4) {
                         Text("\(filtered.count) \(filtered.count == 1 ? "plate" : "plates")")
                         Text("·")
-                        Text("\(Set(filtered.map { $0.family }.filter { !$0.isEmpty }).count) families")
+                        Text("\(Set(filtered.compactMap { $0.identification.family }.filter { !$0.isEmpty }).count) families")
                     }
                     .font(DS.sans(11))
                     .tracking(0.4)
@@ -297,7 +302,7 @@ struct LibraryView: View {
                 let fetched = try await DatabaseService.shared.fetchAllEntries()
                 await MainActor.run {
                     entries = fetched
-                    if let fam = activeFamily, !fetched.contains(where: { $0.family == fam }) {
+                    if let fam = activeFamily, !fetched.contains(where: { $0.identification.family == fam }) {
                         activeFamily = nil
                     }
                     if page >= totalPages { page = 0 }

--- a/Sources/Views/PlateFrameView.swift
+++ b/Sources/Views/PlateFrameView.swift
@@ -40,16 +40,18 @@ struct PlateFrameView: View {
     }
 
     private var header: some View {
-        VStack(spacing: 6) {
+        let id = entry.identification
+        let common = id.commonName ?? "Unidentified"
+        return VStack(spacing: 6) {
             MonoLabel(text: "PLATE \(plateNumber)", color: DS.muted)
                 .padding(.bottom, 8)
-            Text(entry.commonName.uppercased())
+            Text(common.uppercased())
                 .font(DS.serif(28, weight: .regular))
                 .tracking(1.2)
                 .foregroundColor(DS.ink)
                 .multilineTextAlignment(.center)
-            if !entry.scientificName.isEmpty {
-                Text(entry.scientificName)
+            if let scientific = id.scientificName, !scientific.isEmpty {
+                Text(scientific)
                     .font(DS.serif(15, italic: true))
                     .foregroundColor(DS.inkSoft)
                     .padding(.top, 2)
@@ -59,6 +61,7 @@ struct PlateFrameView: View {
 
     @ViewBuilder
     private var illustrationSlot: some View {
+        let placeholderLabel = entry.identification.commonName ?? "Unidentified"
         Group {
             if let preloaded = preloadedIllustration {
                 Image(nsImage: preloaded)
@@ -68,13 +71,13 @@ struct PlateFrameView: View {
                 let url = AppPaths.illustrations.appendingPathComponent(illus)
                 if FileManager.default.fileExists(atPath: url.path) {
                     LocalImage(url: url, refreshToken: refreshToken) {
-                        PlatePlaceholder(label: entry.commonName)
+                        PlatePlaceholder(label: placeholderLabel)
                     }
                 } else {
-                    PlatePlaceholder(label: entry.commonName)
+                    PlatePlaceholder(label: placeholderLabel)
                 }
             } else {
-                PlatePlaceholder(label: entry.commonName)
+                PlatePlaceholder(label: placeholderLabel)
             }
         }
         .frame(maxWidth: .infinity)
@@ -84,8 +87,8 @@ struct PlateFrameView: View {
 
     private var footer: some View {
         HStack {
-            if !entry.family.isEmpty {
-                Text(entry.family)
+            if let family = entry.identification.family, !family.isEmpty {
+                Text(family)
                     .font(DS.serif(13, italic: true))
                     .foregroundColor(DS.mutedDeep)
             }


### PR DESCRIPTION
Two related architectural refactors filed earlier as RFCs. Both are pure refactors — no behaviour changes, no schema migrations, `xcodebuild` green after each commit.

## Summary

- **Commit 1 (#17)** — Replace stringly-typed `Entry.identificationJson` parsing (three independent styles, including a per-field `JSONSerialization` extension that re-parsed on every access) with a single `Identification` value type. Hot path (`LibraryView.filtered` per-keystroke search) now goes through one cached parse instead of three. Kingdom legacy default lives in one place.
- **Commit 2 (#18)** — Collapse `FluxActor` (223 LOC) and `GemmaActor` (263 LOC) — ~95% copy-paste — behind a shared `PythonRPCTransport` actor. Per-model wrappers shrink to typed Codable adapters. New `ModelLease` encodes the "shutdown the other model before this one runs" GPU-memory rule as an invariant instead of a remembered convention in `PipelineService`.

Closes #17.
Closes #18.

## Test plan

- [x] `xcodegen generate && xcodebuild` succeeds after each commit.
- [ ] Smoke-test the import flow end-to-end (drop a photo, confirm Gemma identifies, Flux generates, plate renders).
- [ ] Smoke-test "Regenerate illustration" on an existing entry (verifies the lease releases Gemma cleanly before Flux warms up).
- [ ] Library search filter (verifies the typed `Identification` accessors render the same fields as before).
- [ ] Open a legacy entry whose `identificationJson` predates the `kingdom` key — confirm it still renders as a plant.

## Out of scope (deliberately)

- No new tests — the project has no XCTest target. Both RFCs document the testing strategy that becomes possible now (`ProcessFactory` seam for the transport; `Identification` interface for the model layer).
- No removal of `static let shared` singletons on `GemmaActor`/`FluxActor` — call sites stay stable.
- No collapse of `PipelineService.runFullPipeline`/`runIllustration`/`regenerateIllustration` themselves — partially unblocked by this work but a separate refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)