### PR TITLE
Fix: release Flux eagerly on ModelLease exit so VRAM is freed

### DIFF
--- a/Sources/AI/ModelLease.swift
+++ b/Sources/AI/ModelLease.swift
@@ -1,13 +1,23 @@
 import Foundation
 
-// Encodes the "only one model holds GPU memory at a time" rule as an
-// invariant rather than something every caller has to remember. Any work
-// that wants exclusive access to one tenant shuts down the *other* warm
-// tenant on entry.
+// Encodes two GPU-memory rules as one invariant:
+//
+//   1. Only one model holds GPU memory at a time — taking the lease for
+//      one tenant releases whichever other tenant was warm.
+//   2. Some tenants release eagerly on exit (Flux is heavyweight and
+//      always one-shot per pipeline run); others stay warm so the next
+//      caller skips the warmup cost (Gemma serves consecutive imports).
 
 enum ModelLeaseTenant: Sendable {
-    case identification   // Gemma
-    case illustration     // Flux
+    case identification   // Gemma — kept warm across consecutive identifies
+    case illustration     // Flux — released after each generate to free VRAM
+
+    fileprivate var releasesEagerly: Bool {
+        switch self {
+        case .identification: return false
+        case .illustration:   return true
+        }
+    }
 }
 
 actor ModelLease {
@@ -23,7 +33,21 @@ actor ModelLease {
             await release(other)
         }
         current = tenant
-        return try await work()
+
+        do {
+            let result = try await work()
+            await releaseIfEager(tenant)
+            return result
+        } catch {
+            await releaseIfEager(tenant)
+            throw error
+        }
+    }
+
+    private func releaseIfEager(_ tenant: ModelLeaseTenant) async {
+        guard tenant.releasesEagerly else { return }
+        await release(tenant)
+        if current == tenant { current = nil }
     }
 
     private func release(_ tenant: ModelLeaseTenant) async {


### PR DESCRIPTION
## Summary

Bug introduced by #19. The original `PipelineService` always called `await FluxActor.shared.shutdown()` immediately after every Flux generate. The new `ModelLease` only released the *previous* tenant when a *new* tenant arrived — so after a pipeline run finished with Flux, Flux stayed warm in VRAM with no follow-up to evict it.

Make release-on-exit a per-tenant policy:

- **Flux** releases eagerly on exit (heavyweight, always one-shot per pipeline run).
- **Gemma** stays warm (matches old `PhotoImportService` behaviour, so consecutive imports skip the warmup cost).

| Scenario | After #19 (broken) | This PR |
|---|---|---|
| `PhotoImportService.importPhoto` × N consecutive | Gemma stays warm ✓ | Gemma stays warm ✓ |
| `runFullPipeline` (identify → generate) | Gemma released between, **Flux NOT released ✗** | Gemma released between, Flux released after ✓ |
| `runIllustration` (Flux on existing entry) | **Flux NOT released ✗** | Flux released after ✓ |
| `regenerateIllustration` | **Flux NOT released ✗** | Flux released after ✓ |

## Test plan

- [x] `xcodebuild` succeeds
- [ ] After running a full pipeline, confirm VRAM drops back to baseline (the original symptom)
- [ ] Consecutive imports still skip Gemma warmup

🤖 Generated with [Claude Code](https://claude.com/claude-code)